### PR TITLE
Improve community layout cluster clarity

### DIFF
--- a/multi_agent/topology/visualization/layouts.py
+++ b/multi_agent/topology/visualization/layouts.py
@@ -2,6 +2,7 @@
 Graph layout utilities using NetworkX.
 """
 
+import math
 import networkx as nx
 from typing import Dict
 from networkx.algorithms import community
@@ -34,16 +35,37 @@ def community_layout(G: nx.Graph, offset: float = 4.0, k_inside: float = 0.8) ->
     comms = list(community.greedy_modularity_communities(G))
     pos = {}
 
+    if not comms:
+        return pos
+
+    # Arrange communities in approximately square grid
+    per_row = max(1, math.ceil(math.sqrt(len(comms))))
+
     for i, comm in enumerate(comms):
         subgraph = G.subgraph(comm)
 
         # spring_layout with higher k -> more spread inside community
         sub_pos = nx.spring_layout(subgraph, seed=42, k=k_inside)
 
+        # Center sublayout around origin to avoid skew when applying offsets
+        xs, ys = zip(*sub_pos.values())
+        centroid_x = sum(xs) / len(xs)
+        centroid_y = sum(ys) / len(ys)
+        centered = {
+            node: (coords[0] - centroid_x, coords[1] - centroid_y)
+            for node, coords in sub_pos.items()
+        }
+
+        # Scale clusters based on their size so dense clusters remain readable
+        scale = 1 + math.log(len(comm) + 1, 2)
+
         # Place communities in grid
-        x_shift = (i % 3) * offset   # 3 groups per row
-        y_shift = (i // 3) * offset
-        for node, coords in sub_pos.items():
-            pos[node] = (coords[0] + x_shift, coords[1] + y_shift)
+        x_shift = (i % per_row) * offset
+        y_shift = (i // per_row) * offset
+        for node, coords in centered.items():
+            pos[node] = (
+                coords[0] * scale + x_shift,
+                coords[1] * scale + y_shift,
+            )
 
     return pos


### PR DESCRIPTION
## Summary
- center community layouts before positioning them on the grid
- scale community layouts based on cluster size to make intra-cluster connections clearer
- compute an adaptive grid size to distribute communities more evenly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68deb26810348327a509f77e0d8990cd